### PR TITLE
Spacing tweaks to heading

### DIFF
--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -17,7 +17,7 @@ export const IcebreakerGenerator = ({
 }: Props) => {
   return (
     <div className="flex w-full flex-col items-center justify-center divide-y">
-      <div className="flex items-center justify-center p-6 sm:p-6 sm:pt-7">
+      <div className="flex items-center justify-center p-5 sm:p-6 sm:pt-7">
         <a href="https://parabol.co" target="_blank" rel="noreferrer">
           <Logo className="h-6 w-auto sm:h-8" />
         </a>

--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -17,7 +17,7 @@ export const IcebreakerGenerator = ({
 }: Props) => {
   return (
     <div className="flex w-full flex-col items-center justify-center divide-y">
-      <div className="flex items-center justify-center p-6 sm:p-6">
+      <div className="flex items-center justify-center p-6 sm:p-6 sm:pt-7">
         <a href="https://parabol.co" target="_blank" rel="noreferrer">
           <Logo className="h-6 w-auto sm:h-8" />
         </a>

--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -17,7 +17,7 @@ export const IcebreakerGenerator = ({
 }: Props) => {
   return (
     <div className="flex w-full flex-col items-center justify-center divide-y">
-      <div className="flex items-center justify-center p-6 sm:p-8">
+      <div className="flex items-center justify-center p-6 sm:p-6">
         <a href="https://parabol.co" target="_blank" rel="noreferrer">
           <Logo className="h-6 w-auto sm:h-8" />
         </a>


### PR DESCRIPTION
Small tweaks to the card's header. Reduces the padding and balances the vertical position of the logo.

**Before:**

<img width="648" alt="Captura de Pantalla 2022-07-28 a la(s) 4 18 02 p m" src="https://user-images.githubusercontent.com/3276087/181829335-3718acfa-d183-4485-b51d-0d4cd7279f69.png">

**After:**

<img width="635" alt="Captura de Pantalla 2022-07-29 a la(s) 2 16 35 p m" src="https://user-images.githubusercontent.com/3276087/181829362-e4dbc54e-f3d0-4455-88a6-120fc2e5bb5b.png">

