### PR TITLE
Increases size of icebreaker text

### DIFF
--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -24,7 +24,7 @@ export const IcebreakerGenerator = ({
       </div>
 
       <div className="flex w-full flex-col items-center justify-center space-y-8 p-8">
-        <div className="flex min-h-[170px] items-center justify-center px-4 text-center text-xl sm:min-h-[100px] sm:px-8">
+        <div className="flex min-h-[170px] items-center justify-center px-4 text-center text-2xl sm:min-h-[100px] sm:px-8">
           {currentIcebreaker.question}
         </div>
         <div>


### PR DESCRIPTION
Increases the size of the icebreaker text, from `xl` to `2xl`.

**Before:**

<img width="631" alt="Captura de Pantalla 2022-07-29 a la(s) 2 21 12 p m" src="https://user-images.githubusercontent.com/3276087/181830008-060b70c2-50cd-4c19-8eba-271f04e2f4fc.png">


**After:**

<img width="660" alt="Captura de Pantalla 2022-07-29 a la(s) 2 21 26 p m" src="https://user-images.githubusercontent.com/3276087/181830022-e7b61525-b1c8-48ca-bd0e-e5a748414cf1.png">

