### PR TITLE
Remove copy icebreaker button and replace with link below

### DIFF
--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -6,14 +6,12 @@ interface Props {
   currentIcebreaker: Icebreaker;
   actionLabel: string;
   handleGenerateClick: () => void;
-  handleCopyUrlClick: () => void;
 }
 
 export const IcebreakerGenerator = ({
   currentIcebreaker,
   actionLabel,
   handleGenerateClick,
-  handleCopyUrlClick,
 }: Props) => {
   return (
     <div className="flex w-full flex-col items-center justify-center divide-y">

--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -30,7 +30,6 @@ export const IcebreakerGenerator = ({
         <div>
           <Button
             className="bg-parabol text-white hover:brightness-125"
-            onClick={handleGenerateClick}
           >
             {actionLabel}
           </Button>

--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -30,6 +30,7 @@ export const IcebreakerGenerator = ({
         <div>
           <Button
             className="bg-parabol text-white hover:brightness-125"
+            onClick={handleGenerateClick}
           >
             {actionLabel}
           </Button>

--- a/components/IcebreakerGenerator.tsx
+++ b/components/IcebreakerGenerator.tsx
@@ -37,14 +37,7 @@ export const IcebreakerGenerator = ({
           <div className="mt-2 text-center text-xs">or press space...</div>
         </div>
 
-        <div>
-          <Button
-            className="border border-gray-200 bg-white text-parabol hover:border-gray-300"
-            onClick={handleCopyUrlClick}
-          >
-            Copy this icebreaker URL
-          </Button>
-        </div>
+        
       </div>
     </div>
   );

--- a/components/LinkIcon.tsx
+++ b/components/LinkIcon.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  className?: string;
+}
+
+export const LinkIcon = ({ className }: Props) => {
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      className="h-4 w-4 inline-block mr-2" 
+      viewBox="0 0 20 20" 
+      fill="currentColor">
+    
+      <path 
+        d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" 
+        fillRule="evenodd"
+        clipRule="evenodd" />
+    </svg>
+  );
+};

--- a/components/LinkIcon.tsx
+++ b/components/LinkIcon.tsx
@@ -6,7 +6,7 @@ export const LinkIcon = ({ className }: Props) => {
   return (
     <svg 
       xmlns="http://www.w3.org/2000/svg" 
-      className="h-4 w-4 inline-block mr-2" 
+      className={className} 
       viewBox="0 0 20 20" 
       fill="currentColor">
     

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -49,7 +49,6 @@ const Embed: NextPage<Props> = ({ initialIcebreaker, initialActionLabel }) => {
         currentIcebreaker={icebreaker}
         actionLabel={actionLabel}
         handleGenerateClick={handleGenerateClick}
-        handleCopyUrlClick={handleCopyUrlClick}
       />
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/api";
 import { SSR_CACHE_CONFIG } from "../lib/cache";
 import { SEO_CONFIG } from "../lib/seo/config";
+import { Button } from "../components/Button";
 
 interface Props {
   allIcebreakers: Icebreaker[];
@@ -102,14 +103,13 @@ const Icebreaker: NextPage<Props> = ({
       <div
         className="mx-4 mt-auto mb-4 inline-flex flex-col items-center justify-center gap-2 text-center text-white"
       >
-          <a
-            className="text-sm underline mt-4 inline-block"
+          <Button
+            className="text-sm mt-4 inline-block hover:underline focus:ring-2 focus:ring-offset-0"
             onClick={handleCopyUrlClick}
-            href="#"
           >
             <LinkIcon className="h-4 w-4 inline-block mr-2"/>
             Copy this icebreaker URL
-          </a>
+          </Button>
         </div>
 
       <footer className="mt-4 flex flex-1 justify-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -100,7 +100,7 @@ const Icebreaker: NextPage<Props> = ({
         />
       </Card>
       <div
-        className="group mx-4 mt-auto mb-4 inline-flex flex-col items-center justify-center gap-2 text-center text-white"
+        className="mx-4 mt-auto mb-4 inline-flex flex-col items-center justify-center gap-2 text-center text-white"
       >
           <a
             className="text-sm underline mt-4 inline-block"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Card } from "../components/Card";
 import { IcebreakerGenerator } from "../components/IcebreakerGenerator";
 import { Mark } from "../components/Mark";
+import { LinkIcon } from "../components/linkIcon";
 import { generateRandomActionLabel } from "../lib/actions";
 import {
   allIcebreakers,
@@ -98,6 +99,18 @@ const Icebreaker: NextPage<Props> = ({
           handleCopyUrlClick={handleCopyUrlClick}
         />
       </Card>
+      <div
+        className="group mx-4 mt-auto mb-4 inline-flex flex-col items-center justify-center gap-2 text-center text-white"
+      >
+          <a
+            className="text-sm underline mt-4 inline-block"
+            onClick={handleCopyUrlClick}
+            href="#"
+          >
+            <LinkIcon />
+            Copy this icebreaker URL
+          </a>
+        </div>
 
       <footer className="mt-4 flex flex-1 justify-center">
         <a

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -97,7 +97,6 @@ const Icebreaker: NextPage<Props> = ({
           currentIcebreaker={currentIcebreaker}
           actionLabel={actionLabel}
           handleGenerateClick={handleGenerateClick}
-          handleCopyUrlClick={handleCopyUrlClick}
         />
       </Card>
       <div

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Icebreaker: NextPage<Props> = ({
             onClick={handleCopyUrlClick}
             href="#"
           >
-            <LinkIcon />
+            <LinkIcon className="h-4 w-4 inline-block mr-2"/>
             Copy this icebreaker URL
           </a>
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -104,7 +104,7 @@ const Icebreaker: NextPage<Props> = ({
         className="mx-4 mt-auto mb-4 inline-flex flex-col items-center justify-center gap-2 text-center text-white"
       >
           <Button
-            className="text-sm mt-4 inline-block hover:underline focus:ring-2 focus:ring-offset-0"
+            className="text-sm mt-4 inline-block hover:underline focus:ring-2 focus:ring-offset-0 shadow-none"
             onClick={handleCopyUrlClick}
           >
             <LinkIcon className="h-4 w-4 inline-block mr-2"/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Card } from "../components/Card";
 import { IcebreakerGenerator } from "../components/IcebreakerGenerator";
 import { Mark } from "../components/Mark";
-import { LinkIcon } from "../components/linkIcon";
+import { LinkIcon } from "../components/LinkIcon";
 import { generateRandomActionLabel } from "../lib/actions";
 import {
   allIcebreakers,


### PR DESCRIPTION
Closes #5 

Removes the `Copy this Icebreaker URL` button from within the card, and replaces it with a link below the card.

Before:

<img width="688" alt="Captura de Pantalla 2022-08-05 a la(s) 6 10 51 p m" src="https://user-images.githubusercontent.com/3276087/183222339-bee6cbd2-3cc8-40ff-a06b-1679ea195d3d.png">


After:

<img width="681" alt="Captura de Pantalla 2022-08-05 a la(s) 6 10 59 p m" src="https://user-images.githubusercontent.com/3276087/183222342-b28a58bf-9172-4a2d-96e5-b9b82b37bfe0.png">


@BartoszJarocki This PR will probably make you cringe, but bear with me as I'm very new to React and Tailwind 😄

Do let me know how I can make the code better.